### PR TITLE
강의 테이블 수정 완료

### DIFF
--- a/src/main/java/page/time/api/domain/lecture/domain/Lecture.java
+++ b/src/main/java/page/time/api/domain/lecture/domain/Lecture.java
@@ -2,6 +2,8 @@ package page.time.api.domain.lecture.domain;
 
 import jakarta.annotation.Nullable;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,10 +29,17 @@ public class Lecture {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Type type;
+
     private String professor;
 
     @NotNull
     private String name;
+
+    @NotNull
+    private String groupName;
 
     @NotNull
     private String campus;
@@ -60,4 +69,5 @@ public class Lecture {
 
     private String major;
 
+    private Boolean isExceeded;
 }

--- a/src/main/java/page/time/api/domain/lecture/domain/Type.java
+++ b/src/main/java/page/time/api/domain/lecture/domain/Type.java
@@ -1,0 +1,18 @@
+package page.time.api.domain.lecture.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Type {
+
+    CULTURE("culture","교양"),
+    MAJOR("major", "전공"),
+    TEACHING("teaching", "교직"),
+    ROTC("rotc", "ROTC"),
+    LINKEDFUSION("linkedfusion", "연계융합");
+
+    private String key;
+    private String description;
+}


### PR DESCRIPTION
## Summary

> Lecture 테이블의 칼럼을 수정하였습니다.

강의 정보를 경기대학교 쿠티스에서 스크래핑 하던 중, time 서비스의 강의 정보 조회 기능을 개발할 때 필터링용으로 사용하면 좋을 것 같은 칼럼을 추가했습니다.

1. 강의의 Type을 Enum으로 관리했습니다. 아래 사진과 같이 쿠티스에서 총 5개의 분류로 강의 정보를 제공하고 있습니다. 이처럼 이미 경기대학교 학생들이 많이 접한 분류로 필터링 기능이 time 서비스에 제공된다면 UX적으로 좋을 것 같았습니다. 
Enum을 사용한 이유는, 경기대학교 쿠티스에서 학과 개편을 크게 하지 않는 이상 아래와 같은 분류는 오랫동안 고정되어있을 것이라 생각했습니다.
<img width="608" alt="image" src="https://github.com/user-attachments/assets/dae930f0-5f11-4ac0-a73a-8098f224e30d">


2. groupName이라는 칼럼을 추가했습니다. 기존에는 사용자가 major 칼럼을 활용해 본인의 학과를 검색할 것이라 생각했습니다. 그러나 Type이 전공이 아닌 교양인 경우에는 major 칼럼에 해당되는 데이터가 없었습니다. 사진처럼 드롭다운 박스에서 제공하는 내용이 Type이 교양인 경우 유의미했기에 이를 저장하고자 groupName이라는 칼럼을 만들었습니다.
<img width="595" alt="image" src="https://github.com/user-attachments/assets/bc740699-e09d-4de4-9d01-53d3a5933af7">

Type이 전공인 경우 groupName의 정보는 아래와 같이 선택메뉴의 text로 저장해두었습니다.
<img width="581" alt="image" src="https://github.com/user-attachments/assets/e013661b-b2e8-4560-94b3-958a3980a27b">

3. isExceeded 칼럼이 추가되었습니다. 수강초과된 과목인지, 아닌지 판단할 수 있는 칼럼입니다. 수강신청 시즌과 정정시즌이 되면 수강초과가 안 된 과목을 찾아보는 경우가 많습니다. 해당 칼럼으로 필터링 할 수 있는 API를 만들면 필요한 정보를 사용자에게 줄 수 있을 것 같아서 추가했습니다.

 
## Tasks

- 강의 테이블 수정

