### PR TITLE
과목 필터링 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,12 @@ dependencies {
 	implementation 'com.mysql:mysql-connector-j:9.0.0' // MySQL JDBC Driver
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa' // Spring Data JPA
 
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test' // Spring Boot Test
 	testImplementation 'org.springframework.security:spring-security-test' // Spring Security Test
@@ -46,4 +52,18 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+	main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile) {
+	options.generatedSourceOutputDirectory = file(querydslDir)
+}
+
+clean.doLast {
+	file(querydslDir).deleteDir()
 }

--- a/src/main/java/page/time/api/domain/lecture/application/LectureRetrieveService.java
+++ b/src/main/java/page/time/api/domain/lecture/application/LectureRetrieveService.java
@@ -1,7 +1,6 @@
 package page.time.api.domain.lecture.application;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import page.time.api.domain.lecture.dao.LectureRepository;
 import page.time.api.domain.lecture.domain.Lecture;
@@ -19,20 +18,28 @@ public class LectureRetrieveService {
     private final LectureRepository lectureRepository;
 
     public CursorResult<LectureResponseDto> retrieveLectures(
-            String campus, Type type, Integer grade, List<String> day, List<String> time, String major, Boolean isExceeded, String lectureName, Long cursor, Pageable pageable
+            String campus, Type type, Integer grade, List<String> day, List<String> time, String major, Boolean isExceeded, String lectureName, Long cursor, int limit
     ) {
-        List<Lecture> lectures = lectureRepository.findByFilter(campus, type, grade, day, time, major, isExceeded, lectureName, cursor, pageable);
+        List<Lecture> lectures = lectureRepository.findByFilter(campus, type, grade, day, time, major, isExceeded, lectureName, cursor, limit);
         List<LectureResponseDto> lectureDetailResponseDtos = lectures.stream()
                 .map(LectureResponseDto::toDto)
                 .collect(Collectors.toList());
-        return new CursorResult<>(lectureDetailResponseDtos, checkLastPage(pageable, lectureDetailResponseDtos));
+        return new CursorResult<>(lectureDetailResponseDtos, checkFirstPage(cursor, lectureDetailResponseDtos), checkLastPage(limit, lectureDetailResponseDtos));
     }
 
-    private boolean checkLastPage(Pageable pageable, List<LectureResponseDto> lectureDetailResponseDtos) {
+    private boolean checkFirstPage(Long cursor, List<LectureResponseDto> lectureDetailResponseDtos) {
+        boolean hasPrevious = false;
+        if ((cursor != null) && (lectureDetailResponseDtos.get(0).getId() > cursor)) {
+            hasPrevious = true;
+        }
+        return hasPrevious;
+    }
+
+    private boolean checkLastPage(int limit, List<LectureResponseDto> lectureDetailResponseDtos) {
         boolean hasNext = false;
-        if (lectureDetailResponseDtos.size() > pageable.getPageSize()) {
+        if (lectureDetailResponseDtos.size() > limit) {
             hasNext = true;
-            lectureDetailResponseDtos.remove(pageable.getPageSize());
+            lectureDetailResponseDtos.remove(limit);
         }
         return hasNext;
     }

--- a/src/main/java/page/time/api/domain/lecture/application/LectureRetrieveService.java
+++ b/src/main/java/page/time/api/domain/lecture/application/LectureRetrieveService.java
@@ -1,0 +1,39 @@
+package page.time.api.domain.lecture.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import page.time.api.domain.lecture.dao.LectureRepository;
+import page.time.api.domain.lecture.domain.Lecture;
+import page.time.api.domain.lecture.domain.Type;
+import page.time.api.domain.lecture.dto.response.LectureResponseDto;
+import page.time.api.global.common.CursorResult;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class LectureRetrieveService {
+
+    private final LectureRepository lectureRepository;
+
+    public CursorResult<LectureResponseDto> retrieveLectures(
+            String campus, Type type, Integer grade, List<String> day, List<String> time, String major, Boolean isExceeded, String lectureName, Long cursor, Pageable pageable
+    ) {
+        List<Lecture> lectures = lectureRepository.findByFilter(campus, type, grade, day, time, major, isExceeded, lectureName, cursor, pageable);
+        List<LectureResponseDto> lectureDetailResponseDtos = lectures.stream()
+                .map(LectureResponseDto::toDto)
+                .collect(Collectors.toList());
+        return new CursorResult<>(lectureDetailResponseDtos, checkLastPage(pageable, lectureDetailResponseDtos));
+    }
+
+    private boolean checkLastPage(Pageable pageable, List<LectureResponseDto> lectureDetailResponseDtos) {
+        boolean hasNext = false;
+        if (lectureDetailResponseDtos.size() > pageable.getPageSize()) {
+            hasNext = true;
+            lectureDetailResponseDtos.remove(pageable.getPageSize());
+        }
+        return hasNext;
+    }
+}

--- a/src/main/java/page/time/api/domain/lecture/application/LectureRetrieveService.java
+++ b/src/main/java/page/time/api/domain/lecture/application/LectureRetrieveService.java
@@ -24,23 +24,6 @@ public class LectureRetrieveService {
         List<LectureResponseDto> lectureDetailResponseDtos = lectures.stream()
                 .map(LectureResponseDto::toDto)
                 .collect(Collectors.toList());
-        return new CursorResult<>(lectureDetailResponseDtos, checkFirstPage(cursor, lectureDetailResponseDtos), checkLastPage(limit, lectureDetailResponseDtos));
-    }
-
-    private boolean checkFirstPage(Long cursor, List<LectureResponseDto> lectureDetailResponseDtos) {
-        boolean hasPrevious = false;
-        if ((cursor != null) && (lectureDetailResponseDtos.get(0).getId() > cursor)) {
-            hasPrevious = true;
-        }
-        return hasPrevious;
-    }
-
-    private boolean checkLastPage(int limit, List<LectureResponseDto> lectureDetailResponseDtos) {
-        boolean hasNext = false;
-        if (lectureDetailResponseDtos.size() > limit) {
-            hasNext = true;
-            lectureDetailResponseDtos.remove(limit);
-        }
-        return hasNext;
+        return CursorResult.of(lectureDetailResponseDtos, cursor, limit);
     }
 }

--- a/src/main/java/page/time/api/domain/lecture/controller/LectureRetrieveController.java
+++ b/src/main/java/page/time/api/domain/lecture/controller/LectureRetrieveController.java
@@ -3,7 +3,6 @@ package page.time.api.domain.lecture.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -41,7 +40,7 @@ public class LectureRetrieveController {
             @RequestParam(name = "limit", defaultValue = "50") int limit
     ) {
         CursorResult<LectureResponseDto> lectures = lectureRetrieveService.retrieveLectures(
-                campus, type, grade, day, time, major, isExceeded, lectureName, cursor, PageRequest.of(0, limit)
+                campus, type, grade, day, time, major, isExceeded, lectureName, cursor, limit
         );
         return ApiResponse.success(lectures);
     }

--- a/src/main/java/page/time/api/domain/lecture/controller/LectureRetrieveController.java
+++ b/src/main/java/page/time/api/domain/lecture/controller/LectureRetrieveController.java
@@ -1,0 +1,48 @@
+package page.time.api.domain.lecture.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import page.time.api.domain.lecture.application.LectureRetrieveService;
+import page.time.api.domain.lecture.domain.Type;
+import page.time.api.domain.lecture.dto.response.LectureResponseDto;
+import page.time.api.global.common.ApiResponse;
+import page.time.api.global.common.CursorResult;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/lecture/retrieve")
+@Tag(name = "Lecture - Retrieve", description = "과목 조회")
+public class LectureRetrieveController {
+
+    private final LectureRetrieveService lectureRetrieveService;
+
+    @Operation(summary = "필터링된 과목 조회", description =
+            "8개의 파라미터를 자유롭게 조합하여 필터링 가능<br>" +
+            "모든 파라미터를 하나라도 입력하지 않으면 전체 조회됨<br>")
+    @GetMapping("")
+    public ApiResponse<CursorResult<LectureResponseDto>> retrieveLectures(
+            @RequestParam(name = "campus", required = false) String campus,
+            @RequestParam(name = "type", required = false) Type type,
+            @RequestParam(name = "grade", required = false) Integer grade,
+            @RequestParam(name = "day", required = false) List<String> day,
+            @RequestParam(name = "time", required = false) List<String> time,
+            @RequestParam(name = "major", required = false) String major,
+            @RequestParam(name = "isExceeded", required = false) Boolean isExceeded,
+            @RequestParam(name = "lectureName", required = false) String lectureName,
+            @RequestParam(name = "cursor", required = false) Long cursor,
+            @RequestParam(name = "limit", defaultValue = "50") int limit
+    ) {
+        CursorResult<LectureResponseDto> lectures = lectureRetrieveService.retrieveLectures(
+                campus, type, grade, day, time, major, isExceeded, lectureName, cursor, PageRequest.of(0, limit)
+        );
+        return ApiResponse.success(lectures);
+    }
+}

--- a/src/main/java/page/time/api/domain/lecture/dao/LectureRepository.java
+++ b/src/main/java/page/time/api/domain/lecture/dao/LectureRepository.java
@@ -1,0 +1,9 @@
+package page.time.api.domain.lecture.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import page.time.api.domain.lecture.domain.Lecture;
+
+@Repository
+public interface LectureRepository extends JpaRepository<Lecture, Long>, LectureRepositoryCustom {
+}

--- a/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustom.java
+++ b/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustom.java
@@ -1,0 +1,12 @@
+package page.time.api.domain.lecture.dao;
+
+import org.springframework.data.domain.Pageable;
+import page.time.api.domain.lecture.domain.Lecture;
+import page.time.api.domain.lecture.domain.Type;
+
+import java.util.List;
+
+public interface LectureRepositoryCustom {
+
+    List<Lecture> findByFilter(String campus, Type type, Integer grade, List<String> day, List<String> time, String major, Boolean isExceeded, String lectureName, Long cursor, Pageable pageable);
+}

--- a/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustom.java
+++ b/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustom.java
@@ -1,6 +1,5 @@
 package page.time.api.domain.lecture.dao;
 
-import org.springframework.data.domain.Pageable;
 import page.time.api.domain.lecture.domain.Lecture;
 import page.time.api.domain.lecture.domain.Type;
 
@@ -8,5 +7,5 @@ import java.util.List;
 
 public interface LectureRepositoryCustom {
 
-    List<Lecture> findByFilter(String campus, Type type, Integer grade, List<String> day, List<String> time, String major, Boolean isExceeded, String lectureName, Long cursor, Pageable pageable);
+    List<Lecture> findByFilter(String campus, Type type, Integer grade, List<String> day, List<String> time, String major, Boolean isExceeded, String lectureName, Long cursor, int limit);
 }

--- a/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustomImpl.java
+++ b/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustomImpl.java
@@ -4,7 +4,6 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import page.time.api.domain.lecture.domain.Lecture;
 import page.time.api.domain.lecture.domain.Type;
@@ -20,7 +19,7 @@ public class LectureRepositoryCustomImpl implements LectureRepositoryCustom{
     private final JPAQueryFactory query;
 
     @Override
-    public List<Lecture> findByFilter(String campus, Type type, Integer grade, List<String> day, List<String> time, String major, Boolean isExceeded, String lectureName, Long cursor, Pageable pageable) {
+    public List<Lecture> findByFilter(String campus, Type type, Integer grade, List<String> day, List<String> time, String major, Boolean isExceeded, String lectureName, Long cursor, int limit) {
         return query
                 .selectFrom(lecture)
                 .where(
@@ -34,7 +33,7 @@ public class LectureRepositoryCustomImpl implements LectureRepositoryCustom{
                         containsToLectureName(lectureName),
                         gtCursor(cursor)
                 )
-                .limit(pageable.getPageSize() + 1)
+                .limit(limit + 1)
                 .fetch();
     }
 
@@ -59,25 +58,25 @@ public class LectureRepositoryCustomImpl implements LectureRepositoryCustom{
         return lecture.grade.eq(grade);
     }
 
-    private BooleanBuilder eqToDay(List<String> day) {
-        if (day == null || day.isEmpty()) {
+    private BooleanBuilder eqToDay(List<String> days) {
+        if (days == null || days.isEmpty()) {
             return null;
         }
         BooleanExpression isElearning = lecture.time.eq("이러닝").and(lecture.groupName.contains("이러닝"));
         BooleanBuilder builder = new BooleanBuilder(isElearning);
-        day.stream()
-                .map(d -> lecture.time.startsWith(d)
+        days.stream()
+                .map(day -> lecture.time.startsWith(day)
                         .and(lecture.groupName.contains("이러닝").not()))
                 .forEach(builder::or);
         return builder;
     }
 
-    private BooleanBuilder eqToTime(List<String> time) {
-        if (time == null || time.isEmpty()) {
+    private BooleanBuilder eqToTime(List<String> times) {
+        if (times == null || times.isEmpty()) {
             return null;
         }
         BooleanBuilder builder = new BooleanBuilder();
-        time.stream()
+        times.stream()
                 .map(lecture.time::contains)
                 .forEach(builder::or);
         return builder;

--- a/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustomImpl.java
+++ b/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustomImpl.java
@@ -14,7 +14,7 @@ import static page.time.api.domain.lecture.domain.QLecture.lecture;
 
 @Repository
 @RequiredArgsConstructor
-public class LectureRepositoryCustomImpl implements LectureRepositoryCustom{
+public class LectureRepositoryCustomImpl implements LectureRepositoryCustom {
 
     private final JPAQueryFactory query;
 
@@ -23,14 +23,14 @@ public class LectureRepositoryCustomImpl implements LectureRepositoryCustom{
         return query
                 .selectFrom(lecture)
                 .where(
-                        eqToCampus(campus),
-                        eqToType(type),
-                        eqToGrade(grade),
+                        containsToLectureName(lectureName),
+                        eqToMajor(major),
                         eqToDay(day),
                         eqToTime(time),
-                        eqToMajor(major),
+                        eqToGrade(grade),
+                        eqToType(type),
+                        eqToCampus(campus),
                         eqToIsExceeded(isExceeded),
-                        containsToLectureName(lectureName),
                         gtCursor(cursor)
                 )
                 .limit(limit + 1)
@@ -62,11 +62,9 @@ public class LectureRepositoryCustomImpl implements LectureRepositoryCustom{
         if (days == null || days.isEmpty()) {
             return null;
         }
-        BooleanExpression isElearning = lecture.time.eq("이러닝").and(lecture.groupName.contains("이러닝"));
-        BooleanBuilder builder = new BooleanBuilder(isElearning);
+        BooleanBuilder builder = new BooleanBuilder();
         days.stream()
-                .map(day -> lecture.time.startsWith(day)
-                        .and(lecture.groupName.contains("이러닝").not()))
+                .map(lecture.time::contains)
                 .forEach(builder::or);
         return builder;
     }
@@ -86,7 +84,7 @@ public class LectureRepositoryCustomImpl implements LectureRepositoryCustom{
         if (major == null || major.isEmpty()) {
             return null;
         }
-        return lecture.major.eq(major);
+        return lecture.major.contains(major);
     }
 
     private BooleanExpression eqToIsExceeded(Boolean isExceeded) {

--- a/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustomImpl.java
+++ b/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustomImpl.java
@@ -1,0 +1,113 @@
+package page.time.api.domain.lecture.dao;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import page.time.api.domain.lecture.domain.Lecture;
+import page.time.api.domain.lecture.domain.Type;
+
+import java.util.List;
+
+import static page.time.api.domain.lecture.domain.QLecture.lecture;
+
+@Repository
+@RequiredArgsConstructor
+public class LectureRepositoryCustomImpl implements LectureRepositoryCustom{
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public List<Lecture> findByFilter(String campus, Type type, Integer grade, List<String> day, List<String> time, String major, Boolean isExceeded, String lectureName, Long cursor, Pageable pageable) {
+        return query
+                .selectFrom(lecture)
+                .where(
+                        eqToCampus(campus),
+                        eqToType(type),
+                        eqToGrade(grade),
+                        eqToDay(day),
+                        eqToTime(time),
+                        eqToMajor(major),
+                        eqToIsExceeded(isExceeded),
+                        containsToLectureName(lectureName),
+                        gtCursor(cursor)
+                )
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+    }
+
+    private BooleanExpression eqToCampus(String campus) {
+        if (campus == null || campus.isEmpty()) {
+            return null;
+        }
+        return lecture.campus.contains(campus);
+    }
+
+    private BooleanExpression eqToType(Type type) {
+        if (type == null) {
+            return null;
+        }
+        return lecture.type.eq(type);
+    }
+
+    private BooleanExpression eqToGrade(Integer grade) {
+        if (grade == null) {
+            return null;
+        }
+        return lecture.grade.eq(grade);
+    }
+
+    private BooleanBuilder eqToDay(List<String> day) {
+        if (day == null || day.isEmpty()) {
+            return null;
+        }
+        BooleanExpression isElearning = lecture.time.eq("이러닝").and(lecture.groupName.contains("이러닝"));
+        BooleanBuilder builder = new BooleanBuilder(isElearning);
+        day.stream()
+                .map(d -> lecture.time.startsWith(d)
+                        .and(lecture.groupName.contains("이러닝").not()))
+                .forEach(builder::or);
+        return builder;
+    }
+
+    private BooleanBuilder eqToTime(List<String> time) {
+        if (time == null || time.isEmpty()) {
+            return null;
+        }
+        BooleanBuilder builder = new BooleanBuilder();
+        time.stream()
+                .map(lecture.time::contains)
+                .forEach(builder::or);
+        return builder;
+    }
+
+    private BooleanExpression eqToMajor(String major) {
+        if (major == null || major.isEmpty()) {
+            return null;
+        }
+        return lecture.major.eq(major);
+    }
+
+    private BooleanExpression eqToIsExceeded(Boolean isExceeded) {
+        if (isExceeded == null) {
+            return null;
+        }
+        return lecture.isExceeded.eq(isExceeded);
+    }
+
+    private BooleanExpression containsToLectureName(String lectureName) {
+        if (lectureName == null || lectureName.isEmpty()) {
+            return null;
+        }
+        return lecture.name.containsIgnoreCase(lectureName);
+    }
+
+    private BooleanExpression gtCursor(Long cursor) {
+        if (cursor == null) {
+            return null;
+        }
+        return lecture.id.gt(cursor);
+    }
+}

--- a/src/main/java/page/time/api/domain/lecture/domain/Lecture.java
+++ b/src/main/java/page/time/api/domain/lecture/domain/Lecture.java
@@ -1,6 +1,5 @@
 package page.time.api.domain.lecture.domain;
 
-import jakarta.annotation.Nullable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;

--- a/src/main/java/page/time/api/domain/lecture/dto/response/LectureResponseDto.java
+++ b/src/main/java/page/time/api/domain/lecture/dto/response/LectureResponseDto.java
@@ -7,13 +7,14 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import page.time.api.domain.lecture.domain.Lecture;
 import page.time.api.domain.lecture.domain.Type;
+import page.time.api.global.common.IdProvider;
 
 @Getter
 @Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class LectureResponseDto {
+public class LectureResponseDto implements IdProvider {
 
     private Long id;
     private String campus;

--- a/src/main/java/page/time/api/domain/lecture/dto/response/LectureResponseDto.java
+++ b/src/main/java/page/time/api/domain/lecture/dto/response/LectureResponseDto.java
@@ -1,0 +1,55 @@
+package page.time.api.domain.lecture.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import page.time.api.domain.lecture.domain.Lecture;
+import page.time.api.domain.lecture.domain.Type;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LectureResponseDto {
+
+    private Long id;
+    private String campus;
+    private String category;
+    private String code;
+    private Integer credit;
+    private Integer grade;
+    private String groupName;
+    private Boolean isExceeded;
+    private String major;
+    private String name;
+    private String professor;
+    private String room;
+    private Integer year;
+    private String semester;
+    private String time;
+    private Type type;
+
+    public static LectureResponseDto toDto(Lecture lecture) {
+        return LectureResponseDto.builder()
+                .id(lecture.getId())
+                .campus(lecture.getCampus())
+                .category(lecture.getCategory())
+                .code(lecture.getCode())
+                .credit(lecture.getCredit())
+                .grade(lecture.getGrade())
+                .groupName(lecture.getGroupName())
+                .isExceeded(lecture.getIsExceeded())
+                .major(lecture.getMajor())
+                .name(lecture.getName())
+                .professor(lecture.getProfessor())
+                .room(lecture.getRoom())
+                .year(lecture.getYear())
+                .semester(lecture.getSemester())
+                .time(lecture.getTime())
+                .type(lecture.getType())
+                .build();
+    }
+}

--- a/src/main/java/page/time/api/global/common/CursorResult.java
+++ b/src/main/java/page/time/api/global/common/CursorResult.java
@@ -1,0 +1,17 @@
+package page.time.api.global.common;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CursorResult<T> {
+
+    private List<T> values;
+    private Boolean hasNext;
+
+    public CursorResult(List<T> values, Boolean hasNext) {
+        this.values = values;
+        this.hasNext = hasNext;
+    }
+}

--- a/src/main/java/page/time/api/global/common/CursorResult.java
+++ b/src/main/java/page/time/api/global/common/CursorResult.java
@@ -8,10 +8,12 @@ import java.util.List;
 public class CursorResult<T> {
 
     private List<T> values;
+    private Boolean hasPrevious;
     private Boolean hasNext;
 
-    public CursorResult(List<T> values, Boolean hasNext) {
+    public CursorResult(List<T> values, Boolean hasPrevious, Boolean hasNext) {
         this.values = values;
+        this.hasPrevious = hasPrevious;
         this.hasNext = hasNext;
     }
 }

--- a/src/main/java/page/time/api/global/common/CursorResult.java
+++ b/src/main/java/page/time/api/global/common/CursorResult.java
@@ -7,13 +7,34 @@ import java.util.List;
 @Getter
 public class CursorResult<T> {
 
-    private List<T> values;
-    private Boolean hasPrevious;
-    private Boolean hasNext;
+    private final List<T> values;
+    private final Boolean hasPrevious;
+    private final Boolean hasNext;
 
     public CursorResult(List<T> values, Boolean hasPrevious, Boolean hasNext) {
         this.values = values;
         this.hasPrevious = hasPrevious;
         this.hasNext = hasNext;
+    }
+
+    public static <T extends IdProvider> CursorResult<T> of(List<T> values, Long cursor, int limit) {
+        boolean hasPrevious = checkFirstPageById(cursor, values);
+        boolean hasNext = checkLastPageById(limit, values);
+        return new CursorResult<>(values, hasPrevious, hasNext);
+    }
+
+    private static <T extends IdProvider> boolean checkFirstPageById(Long cursor, List<T> values) {
+        if ((cursor != null) && (cursor > 0) && (!values.isEmpty()) && (values.get(0).getId() > cursor)) {
+            return true;
+        }
+        return false;
+    }
+
+    private static <T extends IdProvider> boolean checkLastPageById(int limit, List<T> values) {
+        if (values.size() > limit) {
+            values.remove(limit);
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/page/time/api/global/common/IdProvider.java
+++ b/src/main/java/page/time/api/global/common/IdProvider.java
@@ -1,0 +1,6 @@
+package page.time.api.global.common;
+
+public interface IdProvider {
+
+    Long getId();
+}

--- a/src/main/java/page/time/api/global/config/QuerydslConfig.java
+++ b/src/main/java/page/time/api/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package page.time.api.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/page/time/api/global/config/SwaggerConfig.java
+++ b/src/main/java/page/time/api/global/config/SwaggerConfig.java
@@ -1,16 +1,11 @@
 package page.time.api.global.config;
 
-import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import lombok.RequiredArgsConstructor;
-import org.springdoc.core.models.GroupedOpenApi;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 


### PR DESCRIPTION
## Summary

> #6 

8가지의 강의 정보로 필터링 할 수 있는 API를 구현했습니다.

## Tasks

- 캠퍼스별 필터링
- 타입 필터링
- 학년 필터링
- 강의 요일 필터링
- 강의 시간 필터링
- 전공명별 필터링
- 전공 초과 여부 필터링
- 과목명 검색
- 커서 기반 페이지네이션 구현

## ETC
**request**
```
String campus // "수원주간", "서울주간", "수원야간", "서울야간", "주간", "야간"으로 검색 가능

Type type // "CULTURE", "MAJOR TEACHING", "ROTC", "LINKEDFUSION"으로 검색 가능

Integer grade // "1", "2", "3", "4"로 검색 가능

List<String> day, // "월", "화", "수", "목", "금", "이러닝"으로 검색 가능

List<String> time, // "1", "2", "3", "4", "5", "6", "7", "8" 등으로 검색 가능

String major, // "컴퓨터공학전공" 등으로 검색 가능

Boolean isExceeded, // true or false

String lectureName, // 과목명 검색
```

**querydsl**
과목 정보는 querydsl의 `BooleanExpression`과 `BooleanBuilder`로 where절을 구성하여 동적 쿼리를 통해 조회됩니다.

**페이지네이션**
`CursorResult`를 통해 과목을 50개씩 끊어 조회한 결과와 다음 페이지 존재 여부(`hasNext`), 이전 페이지 존재 여부(`hasPrevious`)를 반환합니다.
파라미터로 받는 `cursor`는 가장 마지막으로 조회한 과목의 id입니다.

## Screenshot

1. 아무 조건도 넣지 않았을 때
- 요청
![image](https://github.com/user-attachments/assets/bacaa1ca-9cab-4e5e-9f9d-c498f1936f73)

- 결과 : 총 2151개의 강의가 조회됨
```
{
  "success": true,
  "data": {
    "values": [
      {
        "id": 2151,
        "campus": "None",
        "category": "관스",
        "code": "9222",
        "credit": 3,
        "grade": 4,
        "groupName": "None",
        "isExceeded": true,
        "major": "None",
        "name": "관광상품개발연습",
        "professor": null,
        "room": null,
        "year": 2024,
        "semester": "2학기",
        "time": "수 7 8 9",
        "type": "LINKEDFUSION"
      }
    ],
    "hasPrevious": true,
    "hasNext": false
  }
}
```

2. 여러 가지 조건을 조합했을 때
- 요청
![스크린샷 2024-08-02 102735](https://github.com/user-attachments/assets/132f6f22-7a2a-4af8-8b12-0a91ddaf59de)

- 결과 : 조건에 전부 부합하는 강의가 조회됨
```
{
  "success": true,
  "data": {
    "values": [
      {
        "id": 1158,
        "campus": "수원주간",
        "category": "컴터",
        "code": "1193",
        "credit": 3,
        "grade": 3,
        "groupName": "수원주간-컴퓨터공학전공",
        "isExceeded": false,
        "major": "컴퓨터공학전공",
        "name": "머신러닝",
        "professor": "임현기",
        "room": "종합508 강의실(NEW멀티미디어실)",
        "year": 2024,
        "semester": "2학기",
        "time": "월 6 7 8",
        "type": "MAJOR"
      },
      {
        "id": 1159,
        "campus": "수원주간",
        "category": "컴터",
        "code": "1194",
        "credit": 3,
        "grade": 3,
        "groupName": "수원주간-컴퓨터공학전공",
        "isExceeded": false,
        "major": "컴퓨터공학전공",
        "name": "머신러닝",
        "professor": "임현기",
        "room": "8006 강의실(New멀티미디어실)",
        "year": 2024,
        "semester": "2학기",
        "time": "화 6 7 8",
        "type": "MAJOR"
      },
      {
        "id": 1164,
        "campus": "수원주간",
        "category": "컴터",
        "code": "1199",
        "credit": 3,
        "grade": 3,
        "groupName": "수원주간-컴퓨터공학전공",
        "isExceeded": false,
        "major": "컴퓨터공학전공",
        "name": "블록체인플랫폼",
        "professor": "김희열",
        "room": "8008 공용강의실(멀티)",
        "year": 2024,
        "semester": "2학기",
        "time": "화 6 7 8",
        "type": "MAJOR"
      },
      {
        "id": 1172,
        "campus": "수원주간",
        "category": "전선",
        "code": "1207",
        "credit": 3,
        "grade": 3,
        "groupName": "수원주간-컴퓨터공학전공",
        "isExceeded": false,
        "major": "컴퓨터공학전공",
        "name": "모바일프로그래밍",
        "professor": "윤익준",
        "room": "8308 컴퓨터과학전공실습실",
        "year": 2024,
        "semester": "2학기",
        "time": "화 6 7 8",
        "type": "MAJOR"
      }
    ],
    "hasPrevious": false,
    "hasNext": false
  }
}
```