### PR TITLE
전공 필터링 로직 구현 완료

### DIFF
--- a/src/main/java/page/time/api/domain/lecture/application/LectureRetrieveService.java
+++ b/src/main/java/page/time/api/domain/lecture/application/LectureRetrieveService.java
@@ -2,6 +2,7 @@ package page.time.api.domain.lecture.application;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import page.time.api.domain.lecture.dao.LectureRepository;
 import page.time.api.domain.lecture.domain.Lecture;
 import page.time.api.domain.lecture.domain.Type;
@@ -17,6 +18,7 @@ public class LectureRetrieveService {
 
     private final LectureRepository lectureRepository;
 
+    @Transactional(readOnly = true)
     public CursorResult<LectureResponseDto> retrieveLectures(
             String campus, Type type, Integer grade, List<String> day, List<String> time, String major, Boolean isExceeded, String lectureName, Long cursor, int limit
     ) {
@@ -27,6 +29,7 @@ public class LectureRetrieveService {
         return CursorResult.of(lectureDetailResponseDtos, cursor, limit);
     }
 
+    @Transactional(readOnly = true)
     public List<String> retrieveMajor(String major) {
         return lectureRepository.findByMajor(major);
     }

--- a/src/main/java/page/time/api/domain/lecture/application/LectureRetrieveService.java
+++ b/src/main/java/page/time/api/domain/lecture/application/LectureRetrieveService.java
@@ -26,4 +26,8 @@ public class LectureRetrieveService {
                 .collect(Collectors.toList());
         return CursorResult.of(lectureDetailResponseDtos, cursor, limit);
     }
+
+    public List<String> retrieveMajor(String major) {
+        return lectureRepository.findByMajor(major);
+    }
 }

--- a/src/main/java/page/time/api/domain/lecture/controller/LectureRetrieveController.java
+++ b/src/main/java/page/time/api/domain/lecture/controller/LectureRetrieveController.java
@@ -44,4 +44,15 @@ public class LectureRetrieveController {
         );
         return ApiResponse.success(lectures);
     }
+
+    @Operation(summary = "전공 이름 조회", description =
+            "검색된 결과를 토대로 완전한 전공 이름을 조회함<br>" +
+            "입력하지 않으면 전체 조회됨<br>")
+    @GetMapping("/major")
+    public ApiResponse<List<String>> retrieveAllMajor(
+            @RequestParam(name = "major", required = false) String major
+    ) {
+        List<String> majors = lectureRetrieveService.retrieveMajor(major);
+        return ApiResponse.success(majors);
+    }
 }

--- a/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustom.java
+++ b/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustom.java
@@ -8,4 +8,7 @@ import java.util.List;
 public interface LectureRepositoryCustom {
 
     List<Lecture> findByFilter(String campus, Type type, Integer grade, List<String> day, List<String> time, String major, Boolean isExceeded, String lectureName, Long cursor, int limit);
+
+    List<String> findByMajor(String major);
+
 }

--- a/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustom.java
+++ b/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustom.java
@@ -10,5 +10,4 @@ public interface LectureRepositoryCustom {
     List<Lecture> findByFilter(String campus, Type type, Integer grade, List<String> day, List<String> time, String major, Boolean isExceeded, String lectureName, Long cursor, int limit);
 
     List<String> findByMajor(String major);
-
 }

--- a/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustomImpl.java
+++ b/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustomImpl.java
@@ -18,6 +18,8 @@ public class LectureRepositoryCustomImpl implements LectureRepositoryCustom {
 
     private final JPAQueryFactory query;
 
+    private static final String NONE = "None";
+
     @Override
     public List<Lecture> findByFilter(String campus, Type type, Integer grade, List<String> day, List<String> time, String major, Boolean isExceeded, String lectureName, Long cursor, int limit) {
         return query
@@ -44,7 +46,7 @@ public class LectureRepositoryCustomImpl implements LectureRepositoryCustom {
                 .distinct()
                 .from(lecture)
                 .where(
-                        lecture.major.ne("None")
+                        lecture.major.ne(NONE)
                                 .and(eqToMajor(major))
                 )
                 .fetch();

--- a/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustomImpl.java
+++ b/src/main/java/page/time/api/domain/lecture/dao/LectureRepositoryCustomImpl.java
@@ -37,6 +37,19 @@ public class LectureRepositoryCustomImpl implements LectureRepositoryCustom {
                 .fetch();
     }
 
+    @Override
+    public List<String> findByMajor(String major) {
+        return query
+                .select(lecture.major)
+                .distinct()
+                .from(lecture)
+                .where(
+                        lecture.major.ne("None")
+                                .and(eqToMajor(major))
+                )
+                .fetch();
+    }
+
     private BooleanExpression eqToCampus(String campus) {
         if (campus == null || campus.isEmpty()) {
             return null;


### PR DESCRIPTION
## Summary

> #9 

검색 내용을 토대로, 완전한 전공 이름 리스트를 반환하는 api를 구현했습니다.

## Tasks

- string을 받아, 해당하는 완전한 전공 이름을 반환하는 로직 구현

## ETC


## Screenshot

![스크린샷 2024-08-15 213258](https://github.com/user-attachments/assets/94700e69-0012-4a1f-8fbd-0ecbcf26dbd8)
![스크린샷 2024-08-15 213310](https://github.com/user-attachments/assets/d7f30358-47a5-43a8-b92c-6febfc2644a7)

