### PR TITLE
시간표 강의 추가에 사용되는 강의정보 반환 로직 작성 완료

### DIFF
--- a/src/main/java/page/time/api/domain/lecture/application/LectureRetrieveService.java
+++ b/src/main/java/page/time/api/domain/lecture/application/LectureRetrieveService.java
@@ -7,9 +7,11 @@ import page.time.api.domain.lecture.dao.LectureRepository;
 import page.time.api.domain.lecture.domain.Lecture;
 import page.time.api.domain.lecture.domain.Type;
 import page.time.api.domain.lecture.dto.response.LectureResponseDto;
+import page.time.api.domain.lecture.dto.response.LectureSelectResponseDto;
 import page.time.api.global.common.CursorResult;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -32,5 +34,14 @@ public class LectureRetrieveService {
     @Transactional(readOnly = true)
     public List<String> retrieveMajor(String major) {
         return lectureRepository.findByMajor(major);
+    }
+
+    @Transactional(readOnly = true)
+    public List<LectureSelectResponseDto> retrieveSelectedLecturesByIds(List<Long> lectureIds) {
+        return lectureIds.stream()
+                .map(id -> lectureRepository.findById(id).orElse(null))
+                .filter(Objects::nonNull)
+                .map(LectureSelectResponseDto::toDto)
+                .toList();
     }
 }

--- a/src/main/java/page/time/api/domain/lecture/application/LectureRetrieveService.java
+++ b/src/main/java/page/time/api/domain/lecture/application/LectureRetrieveService.java
@@ -11,7 +11,7 @@ import page.time.api.domain.lecture.dto.response.LectureSelectResponseDto;
 import page.time.api.global.common.CursorResult;
 
 import java.util.List;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -39,8 +39,8 @@ public class LectureRetrieveService {
     @Transactional(readOnly = true)
     public List<LectureSelectResponseDto> retrieveSelectedLecturesByIds(List<Long> lectureIds) {
         return lectureIds.stream()
-                .map(id -> lectureRepository.findById(id).orElse(null))
-                .filter(Objects::nonNull)
+                .map(lectureRepository::findById)
+                .flatMap(Optional::stream)
                 .map(LectureSelectResponseDto::toDto)
                 .toList();
     }

--- a/src/main/java/page/time/api/domain/lecture/controller/LectureRetrieveController.java
+++ b/src/main/java/page/time/api/domain/lecture/controller/LectureRetrieveController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import page.time.api.domain.lecture.application.LectureRetrieveService;
 import page.time.api.domain.lecture.domain.Type;
 import page.time.api.domain.lecture.dto.response.LectureResponseDto;
+import page.time.api.domain.lecture.dto.response.LectureSelectResponseDto;
 import page.time.api.global.common.ApiResponse;
 import page.time.api.global.common.CursorResult;
 
@@ -54,5 +55,14 @@ public class LectureRetrieveController {
     ) {
         List<String> majors = lectureRetrieveService.retrieveMajor(major);
         return ApiResponse.success(majors);
+    }
+
+    @Operation(summary = "선택한 강의 id 리스트에 맞는 강의 정보 조회")
+    @GetMapping("/select")
+    public ApiResponse<List<LectureSelectResponseDto>> retrieveLecturesById(
+            @RequestParam List<Long> lectureIds
+    ) {
+        List<LectureSelectResponseDto> lectures = lectureRetrieveService.retrieveSelectedLecturesByIds(lectureIds);
+        return ApiResponse.success(lectures);
     }
 }

--- a/src/main/java/page/time/api/domain/lecture/dto/response/LectureResponseDto.java
+++ b/src/main/java/page/time/api/domain/lecture/dto/response/LectureResponseDto.java
@@ -1,19 +1,13 @@
 package page.time.api.domain.lecture.dto.response;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 import page.time.api.domain.lecture.domain.Lecture;
 import page.time.api.domain.lecture.domain.Type;
 import page.time.api.global.common.IdProvider;
 
 @Getter
-@Setter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class LectureResponseDto implements IdProvider {
 
     private Long id;

--- a/src/main/java/page/time/api/domain/lecture/dto/response/LectureSelectResponseDto.java
+++ b/src/main/java/page/time/api/domain/lecture/dto/response/LectureSelectResponseDto.java
@@ -1,0 +1,39 @@
+package page.time.api.domain.lecture.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import page.time.api.domain.lecture.domain.Lecture;
+import page.time.api.domain.lecture.domain.Type;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LectureSelectResponseDto {
+
+    private Long id;
+    private String campus;
+    private Type type;
+    private String category;
+    private String name;
+    private String professor;
+    private String room;
+    private String time;
+
+    public static LectureSelectResponseDto toDto(Lecture lecture) {
+        return LectureSelectResponseDto.builder()
+                .id(lecture.getId())
+                .campus(lecture.getCampus())
+                .type(lecture.getType())
+                .category(lecture.getCategory())
+                .name(lecture.getName())
+                .professor(lecture.getProfessor())
+                .room(lecture.getRoom())
+                .time(lecture.getTime())
+                .build();
+    }
+}

--- a/src/main/java/page/time/api/domain/lecture/dto/response/LectureSelectResponseDto.java
+++ b/src/main/java/page/time/api/domain/lecture/dto/response/LectureSelectResponseDto.java
@@ -1,18 +1,12 @@
 package page.time.api.domain.lecture.dto.response;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 import page.time.api.domain.lecture.domain.Lecture;
 import page.time.api.domain.lecture.domain.Type;
 
 @Getter
-@Setter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class LectureSelectResponseDto {
 
     private Long id;


### PR DESCRIPTION
## Summary

> #10 

강의 id를 리스트로 받아 해당되는 강의를 조회해 **시간표에 보여질 강의 정보**만 반환하는 로직을 구현했습니다.
시간표에 보여질 강의 정보는 다음과 같습니다.
- campus
- type
- category
- name
- professor
- room
- time

## Tasks

- id에 맞는 시간표 전용 강의정보 반환 api 구현

## ETC


## Screenshot

![스크린샷 2024-08-16 202625](https://github.com/user-attachments/assets/6434bc66-b922-494e-8492-7d9da27125f0)

